### PR TITLE
Support non-`px` value in `font-size` mixin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.sass-cache

--- a/scss/base/_base.scss
+++ b/scss/base/_base.scss
@@ -9,7 +9,9 @@
   }
 
   body {
+    @include base-font(base);
     color: $color-typography-base;
+    background-color: $color-white;
   }
 
   * {

--- a/scss/base/_typography.scss
+++ b/scss/base/_typography.scss
@@ -8,8 +8,18 @@ $base-font-size: 16px;
 
 @mixin font-size($size: $base-font-size) {
   @if $size != none {
-    @if unit($size) != 'px' {
+    // if this is for the base element for `rem` (e.g. body)
+    // - use the `px` based `$base-font-size`
+    @if $size == base {
+      font-size: $base-font-size;
+
+    // if `$size` is not `px` based (e.g. if it's `em` based)
+    // - use only that value
+    } @else if unit($size) != 'px' {
       font-size: $size;
+
+    // ok, this is not the base for `rem` and `$size` is `px` based
+    // - use both the `px` based `$size` value and a calculated `rem` value
     } @else {
       $rem: #{$size / $base-font-size}rem;
       font-size: $size;
@@ -18,16 +28,16 @@ $base-font-size: 16px;
   }
 }
 
-@mixin font-base-attributes($size, $weight, $style) {
-  @include font-size($size);
-  font-weight: $weight;
-
-  @if $style != normal { font-style: $style; }
+@mixin font-base-attributes($size: none, $weight: none, $style: none, $line-height: none) {
+  @if $size != none { @include font-size($size); }
+  @if $weight != none { font-weight: $weight; }
+  @if $style != none { font-style: $style; }
+  @if $line-height != none { line-height: $line-height; }
 }
 
-@mixin base-font($size: 16px, $weight: inherit, $style: normal) {
-  @include font-base-attributes($size, $weight, $style);
-  font-family: 'Helvetica', sans-serif;
+@mixin base-font($size: none, $weight: none, $style: none, $line-height: none) {
+  @include font-base-attributes($size, $weight, $style, $line-height);
+  font-family: Helvetica, sans-serif;
 }
 
 /* _typography small */
@@ -53,4 +63,3 @@ $base-font-size: 16px;
 @include layout-large {
 
 }
-

--- a/scss/base/_typography.scss
+++ b/scss/base/_typography.scss
@@ -1,11 +1,21 @@
 /* _typography.scss */
 
+/* _typography config */
+
+$base-font-size: 16px;
+
 /* _typography mixins */
 
-@mixin font-size($size: 16px) {
-  $rem: #{$size / 16px}rem;
-  font-size: $size;
-  font-size: $rem;
+@mixin font-size($size: $base-font-size) {
+  @if $size != none {
+    @if unit($size) != 'px' {
+      font-size: $size;
+    } @else {
+      $rem: #{$size / $base-font-size}rem;
+      font-size: $size;
+      font-size: $rem;
+    }
+  }
 }
 
 @mixin font-base-attributes($size, $weight, $style) {

--- a/scss/helpers/_functions.scss
+++ b/scss/helpers/_functions.scss
@@ -1,0 +1,6 @@
+/* _functions.scss */
+
+@function strip-unit($unit) {
+  $stripped: $unit / ($unit * 0 + 1);
+  @return $stripped;
+}

--- a/scss/helpers/_functions.scss
+++ b/scss/helpers/_functions.scss
@@ -1,6 +1,0 @@
-/* _functions.scss */
-
-@function strip-unit($unit) {
-  $stripped: $unit / ($unit * 0 + 1);
-  @return $stripped;
-}

--- a/scss/modules/_grid.scss
+++ b/scss/modules/_grid.scss
@@ -7,7 +7,7 @@ $grid-col-padding: 15px;
 
 /* _grid base */
 @include layout-default {
-  
+
   .container-fluid { width: 100%; }
 
   .container {


### PR DESCRIPTION
This allows to use the `font-size` mixin (used by e.g. `base-font` mixin) without passing a `px` based value. If `$size` is not `px` based the value is outputted directly.