### PR TITLE
Remove non-media-query specific grid util classes

### DIFF
--- a/scss/base/_variables.scss
+++ b/scss/base/_variables.scss
@@ -10,6 +10,7 @@ $site-max-width: 1240px;
 
 /* Breakpoints */
 
+$bp-small: '(max-width: 549px)';
 $bp-medium: '(min-width: 550px) and (max-width: 1000px)';
 $bp-medium-and-above: '(min-width: 550px)';
 $bp-large: '(min-width: 1001px)';

--- a/scss/media-queries/_media-queries.scss
+++ b/scss/media-queries/_media-queries.scss
@@ -12,6 +12,12 @@
   }
 }
 
+@mixin layout-small {
+  @include respond-to(small) {
+    @content;
+  }
+}
+
 @mixin layout-medium {
   @include respond-to(medium) {
     @content;

--- a/scss/modules/_grid.scss
+++ b/scss/modules/_grid.scss
@@ -38,10 +38,12 @@ $grid-col-padding: 15px;
       padding-left: $grid-col-padding;
     }
   }
+}
 
+/* _grid small */
+
+@include layout-small {
   .hide-sm { display: none; }
-
-  /* _grid states and modifiers */
 }
 
 /* _grid medium */

--- a/scss/modules/_grid.scss
+++ b/scss/modules/_grid.scss
@@ -39,8 +39,7 @@ $grid-col-padding: 15px;
     }
   }
 
-  .hide-sm,
-  .hide-sm-inline { display: none; }
+  .hide-sm { display: none; }
 
   /* _grid states and modifiers */
 }
@@ -66,18 +65,12 @@ $grid-col-padding: 15px;
 /* _grid medium-and-above */
 
 @include layout-medium-and-above {
-  .hide-sm { display: block; }
-
   .hide-md-lg { display: none; }
-
-  .hide-sm-inline { display: inline; }
 }
 
 /* _grid large */
 
 @include layout-large {
-  .hide-md { display: block; }
-
   .hide-lg { display: none; }
 
   @for $i from 1 through $grid-cols {

--- a/style.scss
+++ b/style.scss
@@ -17,6 +17,11 @@
 $layout-size: default;
 @import "scss/all";
 
+@media #{$bp-small} {
+  $layout-size: small;
+  @import "scss/all";
+}
+
 @media #{$bp-medium} {
   $layout-size: medium;
   @import "scss/all";


### PR DESCRIPTION
We should only use grid util classes (e.g. `.hide-sm`) to set
`display: none` in the media query that the class name is related to
(i.e. `.hide-sm` should only be referenced in the media query related to
the "small" layout").